### PR TITLE
Switch image over to SVG and prevent tickets.csv updates with no changes

### DIFF
--- a/drop.py
+++ b/drop.py
@@ -1,0 +1,21 @@
+# Small script to drop duplicate rows
+
+from pandas import read_csv
+
+filename = "tickets.csv"
+data = read_csv(filename)
+
+last = None
+for idx, row in data.iterrows():
+    if last is None:
+        last = row
+        continue
+
+    differences = [key for key in row.keys() if key != 'utc_epoch_time' and (
+            (last[key] != row[key]).any()
+    )]
+    last = row
+    if not differences:
+        data = data[data.utc_epoch_time != row.utc_epoch_time]
+
+data.to_csv(filename, index=False)

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def plot_counters(data):
     list_data = {key: data[key].to_list() for key in data.keys() if not any([hidden in key for hidden in hidden_list])}
 
     fig, ax = plt.subplots()
-    fig.set_facecolor("#491d88")
+    fig.patch.set_alpha(0)
     ax.set_facecolor("#fec859")
     ax.set_prop_cycle(cycler(color=["#fa448c", "#43b5a0", "#331a38"]))
     ax.xaxis.label.set_color("white")
@@ -45,7 +45,7 @@ def plot_counters(data):
     ax.tick_params(axis="y", which="both", colors="white")
 
     ax.stackplot(timestamps, list_data.values(),
-                 labels=list_data.keys(), alpha=0.8)
+                 labels=list_data.keys(), alpha=0.8, step='post')
     ax.axhline(y=1500, color="limegreen", linestyle="--", label="Required tickets w/ donations")
     ax.legend(loc="upper left")
     ax.set_title("MCH Tickets", color="white")
@@ -55,7 +55,7 @@ def plot_counters(data):
     ax.xaxis.set_major_formatter(mdates.DateFormatter("%a %m/%d"))
 
     plt.gcf().autofmt_xdate()
-    plt.savefig("mch2022tickets.png")
+    plt.savefig("mch2022tickets.svg", dpi=350)
 
 
 async def process_tickets(tickets):

--- a/main.py
+++ b/main.py
@@ -25,8 +25,16 @@ def get_updated_counters(tickets):
 
     filename = "tickets.csv"
     data = read_csv(filename)
+
+    last = data.tail(1)
+    differences = [key for key in new_data.keys() if key != 'utc_epoch_time' and (last[key] != new_data[key]).any()]
+
+    # Append the current row anyhow to move the graph forward
     data = data.append(DataFrame(new_data), ignore_index=True)
-    data.to_csv(filename, index=False)
+
+    if differences:
+        data.to_csv(filename, index=False)
+
     return data
 
 


### PR DESCRIPTION
There's also a drop.py script in here: The intention is we'll use it once to triage the .csv when 40b154835364c2d0cb4d71b29f08c61d35b8df60 has been merged in

The .svg is for mobile users: it is a ton clearer to read (there's no blur visible).
The duplicate data purge is needed so the .svg is smaller in size...